### PR TITLE
Added additional custom attributes to handle "tap", "press", and "hold" events using hammer.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
 # aurelia-hammer
 
-This is a [Aurelia](http://www.aurelia.io/) plugin providing the `hammer-swipe` Custom Attribute.
+This is a [Aurelia](http://www.aurelia.io/) plugin providing the `hammer-swipe` and `hammer-press` and `hammer-hold` Custom Attributes.
+
 It uses [HammerJS](http://hammerjs.github.io/) to detect the gesture.
 
-`swipe` is the only gesture supported at the moment. If you need another, feel free to open an issue or send a PR.
+`swipe`, `press`, and `hold` are the only gestures supported at the moment. If you need another, feel free to open an issue or send a PR.
+
+* **Swipe** - Captures left/right swipe gestures
+* **Press** - Captures when the pointer is down for 251ms without movement
+* **Hold** - Captures when the pointer is down for 1000ms without movement
 
 ## Installation
 `jspm install github:benib/aurelia-hammer`
@@ -16,7 +21,7 @@ aurelia.use
   //...
 ```
 
-## Usage
+## Swipe Usage
 In your View
 ```html
 <div hammer-swipe.call="handleSwipe($event)">
@@ -33,3 +38,34 @@ handleSwipe($event) {
   // here you have $event.hammerEvent holding the original event from HammerJS.
 }
 ```
+
+# Press Usage
+
+In your View
+```html
+<div hammer-press.call="handlePress($event)">
+</div>
+```
+In your View Model
+```js
+handlePress($event) {
+  
+  // here you have $event.hammerEvent holding the original event from HammerJS.
+}
+```
+
+# Hold Usage
+
+In your View
+```html
+<div hammer-hold.call="handleHold($event)">
+</div>
+```
+In your View Model
+```js
+handleHold($event) {
+  
+  // here you have $event.hammerEvent holding the original event from HammerJS.
+}
+```
+

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ This is a [Aurelia](http://www.aurelia.io/) plugin providing the `hammer-swipe` 
 
 It uses [HammerJS](http://hammerjs.github.io/) to detect the gesture.
 
-`swipe`, `press`, and `hold` are the only gestures supported at the moment. If you need another, feel free to open an issue or send a PR.
+`swipe`, `tap`, `press`, and `hold` are the only gestures supported at the moment. If you need another, feel free to open an issue or send a PR.
 
 * **Swipe** - Captures left/right swipe gestures
+* **Tap** - Captures when the pointer is down for up to 250ms without movement
 * **Press** - Captures when the pointer is down for 251ms without movement
 * **Hold** - Captures when the pointer is down for 1000ms without movement
 
@@ -38,6 +39,22 @@ handleSwipe($event) {
   // here you have $event.hammerEvent holding the original event from HammerJS.
 }
 ```
+
+# Tap Usage
+
+In your View
+```html
+<div hammer-press.call="handlePress($event)">
+</div>
+```
+In your View Model
+```js
+handlePress($event) {
+  
+  // here you have $event.hammerEvent holding the original event from HammerJS.
+}
+```
+
 
 # Press Usage
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # aurelia-hammer
 
-This is a [Aurelia](http://www.aurelia.io/) plugin providing the `hammer-swipe` and `hammer-press` and `hammer-hold` Custom Attributes.
+This is a [Aurelia](http://www.aurelia.io/) plugin providing the `hammer-swipe` and `hammer-tap` and `hammer-press` and `hammer-hold` Custom Attributes.
 
 It uses [HammerJS](http://hammerjs.github.io/) to detect the gesture.
 
@@ -40,7 +40,7 @@ handleSwipe($event) {
 }
 ```
 
-# Tap Usage
+## Tap Usage
 
 In your View
 ```html
@@ -56,7 +56,7 @@ handlePress($event) {
 ```
 
 
-# Press Usage
+## Press Usage
 
 In your View
 ```html
@@ -71,7 +71,7 @@ handlePress($event) {
 }
 ```
 
-# Hold Usage
+## Hold Usage
 
 In your View
 ```html

--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ handleSwipe($event) {
 
 In your View
 ```html
-<div hammer-press.call="handlePress($event)">
+<div hammer-tap.call="handleTap($event)">
 </div>
 ```
 In your View Model
 ```js
-handlePress($event) {
+handleTap($event) {
   
   // here you have $event.hammerEvent holding the original event from HammerJS.
 }

--- a/dist/amd/hammer-hold.js
+++ b/dist/amd/hammer-hold.js
@@ -49,7 +49,7 @@ define(['exports', 'aurelia-framework', 'hammerjs'], function (exports, _aurelia
 
     var _HammerPressCustomAttribute = HammerPressCustomAttribute;
     HammerPressCustomAttribute = (0, _aureliaFramework.inject)(Element)(HammerPressCustomAttribute) || HammerPressCustomAttribute;
-    HammerPressCustomAttribute = (0, _aureliaFramework.customAttribute)('hammer-press')(HammerPressCustomAttribute) || HammerPressCustomAttribute;
+    HammerPressCustomAttribute = (0, _aureliaFramework.customAttribute)('hammer-hold')(HammerPressCustomAttribute) || HammerPressCustomAttribute;
     return HammerPressCustomAttribute;
   })();
 

--- a/dist/amd/hammer-hold.js
+++ b/dist/amd/hammer-hold.js
@@ -1,0 +1,57 @@
+define(['exports', 'aurelia-framework', 'hammerjs'], function (exports, _aureliaFramework, _hammerjs) {
+  'use strict';
+
+  Object.defineProperty(exports, '__esModule', {
+    value: true
+  });
+
+  var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+  function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+  function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
+
+  var _Hammer = _interopRequireDefault(_hammerjs);
+
+  var HammerPressCustomAttribute = (function () {
+    function HammerPressCustomAttribute(element) {
+      _classCallCheck(this, _HammerPressCustomAttribute);
+
+      this.hammer = new _Hammer['default'].Manager(element, {
+        recognizers: [[_Hammer['default'].Press, { time: 1000 }]]
+      });
+      this.element = element;
+    }
+
+    _createClass(HammerPressCustomAttribute, [{
+      key: 'attached',
+      value: function attached() {
+        this.hammer.on('press', this.handleSwipe.bind(this));
+      }
+    }, {
+      key: 'detached',
+      value: function detached() {
+        this.hammer.off('press', this.handleSwipe.bind(this));
+      }
+    }, {
+      key: 'valueChanged',
+      value: function valueChanged(newValue) {
+        this.callback = newValue;
+      }
+    }, {
+      key: 'handleSwipe',
+      value: function handleSwipe(event) {
+        if (this.callback) {
+          this.callback.call(null, { hammerEvent: event });
+        }
+      }
+    }]);
+
+    var _HammerPressCustomAttribute = HammerPressCustomAttribute;
+    HammerPressCustomAttribute = (0, _aureliaFramework.inject)(Element)(HammerPressCustomAttribute) || HammerPressCustomAttribute;
+    HammerPressCustomAttribute = (0, _aureliaFramework.customAttribute)('hammer-press')(HammerPressCustomAttribute) || HammerPressCustomAttribute;
+    return HammerPressCustomAttribute;
+  })();
+
+  exports.HammerPressCustomAttribute = HammerPressCustomAttribute;
+});

--- a/dist/amd/hammer-press.js
+++ b/dist/amd/hammer-press.js
@@ -1,0 +1,57 @@
+define(['exports', 'aurelia-framework', 'hammerjs'], function (exports, _aureliaFramework, _hammerjs) {
+  'use strict';
+
+  Object.defineProperty(exports, '__esModule', {
+    value: true
+  });
+
+  var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+  function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+  function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
+
+  var _Hammer = _interopRequireDefault(_hammerjs);
+
+  var HammerPressCustomAttribute = (function () {
+    function HammerPressCustomAttribute(element) {
+      _classCallCheck(this, _HammerPressCustomAttribute);
+
+      this.hammer = new _Hammer['default'].Manager(element, {
+        recognizers: [[_Hammer['default'].Press]]
+      });
+      this.element = element;
+    }
+
+    _createClass(HammerPressCustomAttribute, [{
+      key: 'attached',
+      value: function attached() {
+        this.hammer.on('press', this.handleSwipe.bind(this));
+      }
+    }, {
+      key: 'detached',
+      value: function detached() {
+        this.hammer.off('press', this.handleSwipe.bind(this));
+      }
+    }, {
+      key: 'valueChanged',
+      value: function valueChanged(newValue) {
+        this.callback = newValue;
+      }
+    }, {
+      key: 'handleSwipe',
+      value: function handleSwipe(event) {
+        if (this.callback) {
+          this.callback.call(null, { hammerEvent: event });
+        }
+      }
+    }]);
+
+    var _HammerPressCustomAttribute = HammerPressCustomAttribute;
+    HammerPressCustomAttribute = (0, _aureliaFramework.inject)(Element)(HammerPressCustomAttribute) || HammerPressCustomAttribute;
+    HammerPressCustomAttribute = (0, _aureliaFramework.customAttribute)('hammer-press')(HammerPressCustomAttribute) || HammerPressCustomAttribute;
+    return HammerPressCustomAttribute;
+  })();
+
+  exports.HammerPressCustomAttribute = HammerPressCustomAttribute;
+});

--- a/dist/amd/hammer-tap.js
+++ b/dist/amd/hammer-tap.js
@@ -26,12 +26,12 @@ define(['exports', 'aurelia-framework', 'hammerjs'], function (exports, _aurelia
     _createClass(HammerTapCustomAttribute, [{
       key: 'attached',
       value: function attached() {
-        this.hammer.on('press', this.handleTap.bind(this));
+        this.hammer.on('tap', this.handleTap.bind(this));
       }
     }, {
       key: 'detached',
       value: function detached() {
-        this.hammer.off('press', this.handleTap.bind(this));
+        this.hammer.off('tap', this.handleTap.bind(this));
       }
     }, {
       key: 'valueChanged',
@@ -39,8 +39,8 @@ define(['exports', 'aurelia-framework', 'hammerjs'], function (exports, _aurelia
         this.callback = newValue;
       }
     }, {
-      key: 'handleSwipe',
-      value: function handleSwipe(event) {
+      key: 'handleTap',
+      value: function handleTap(event) {
         if (this.callback) {
           this.callback.call(null, { hammerEvent: event });
         }

--- a/dist/amd/hammer-tap.js
+++ b/dist/amd/hammer-tap.js
@@ -1,0 +1,57 @@
+define(['exports', 'aurelia-framework', 'hammerjs'], function (exports, _aureliaFramework, _hammerjs) {
+  'use strict';
+
+  Object.defineProperty(exports, '__esModule', {
+    value: true
+  });
+
+  var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+  function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+  function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
+
+  var _Hammer = _interopRequireDefault(_hammerjs);
+
+  var HammerTapCustomAttribute = (function () {
+    function HammerTapCustomAttribute(element) {
+      _classCallCheck(this, _HammerTapCustomAttribute);
+
+      this.hammer = new _Hammer['default'].Manager(element, {
+        recognizers: [[_Hammer['default'].Tap]]
+      });
+      this.element = element;
+    }
+
+    _createClass(HammerTapCustomAttribute, [{
+      key: 'attached',
+      value: function attached() {
+        this.hammer.on('press', this.handleTap.bind(this));
+      }
+    }, {
+      key: 'detached',
+      value: function detached() {
+        this.hammer.off('press', this.handleTap.bind(this));
+      }
+    }, {
+      key: 'valueChanged',
+      value: function valueChanged(newValue) {
+        this.callback = newValue;
+      }
+    }, {
+      key: 'handleSwipe',
+      value: function handleSwipe(event) {
+        if (this.callback) {
+          this.callback.call(null, { hammerEvent: event });
+        }
+      }
+    }]);
+
+    var _HammerTapCustomAttribute = HammerTapCustomAttribute;
+    HammerTapCustomAttribute = (0, _aureliaFramework.inject)(Element)(HammerTapCustomAttribute) || HammerTapCustomAttribute;
+    HammerTapCustomAttribute = (0, _aureliaFramework.customAttribute)('hammer-tap')(HammerTapCustomAttribute) || HammerTapCustomAttribute;
+    return HammerTapCustomAttribute;
+  })();
+
+  exports.HammerTapCustomAttribute = HammerTapCustomAttribute;
+});

--- a/dist/amd/index.js
+++ b/dist/amd/index.js
@@ -8,6 +8,7 @@ define(['exports'], function (exports) {
 
   function configure(frameworkConfig) {
     frameworkConfig.globalResources('./hammer-swipe');
+    frameworkConfig.globalResources('./hammer-tap');
     frameworkConfig.globalResources('./hammer-press');
     frameworkConfig.globalResources('./hammer-hold');
   }

--- a/dist/amd/index.js
+++ b/dist/amd/index.js
@@ -8,5 +8,7 @@ define(['exports'], function (exports) {
 
   function configure(frameworkConfig) {
     frameworkConfig.globalResources('./hammer-swipe');
+    frameworkConfig.globalResources('./hammer-press');
+    frameworkConfig.globalResources('./hammer-hold');
   }
 });

--- a/dist/commonjs/hammer-hold.js
+++ b/dist/commonjs/hammer-hold.js
@@ -52,7 +52,7 @@ var HammerPressCustomAttribute = (function () {
 
   var _HammerPressCustomAttribute = HammerPressCustomAttribute;
   HammerPressCustomAttribute = (0, _aureliaFramework.inject)(Element)(HammerPressCustomAttribute) || HammerPressCustomAttribute;
-  HammerPressCustomAttribute = (0, _aureliaFramework.customAttribute)('hammer-press')(HammerPressCustomAttribute) || HammerPressCustomAttribute;
+  HammerPressCustomAttribute = (0, _aureliaFramework.customAttribute)('hammer-hold')(HammerPressCustomAttribute) || HammerPressCustomAttribute;
   return HammerPressCustomAttribute;
 })();
 

--- a/dist/commonjs/hammer-hold.js
+++ b/dist/commonjs/hammer-hold.js
@@ -1,0 +1,59 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+
+var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
+
+var _aureliaFramework = require('aurelia-framework');
+
+var _hammerjs = require('hammerjs');
+
+var _hammerjs2 = _interopRequireDefault(_hammerjs);
+
+var HammerPressCustomAttribute = (function () {
+  function HammerPressCustomAttribute(element) {
+    _classCallCheck(this, _HammerPressCustomAttribute);
+
+    this.hammer = new _hammerjs2['default'].Manager(element, {
+      recognizers: [[_hammerjs2['default'].Press, { time: 1000 }]]
+    });
+    this.element = element;
+  }
+
+  _createClass(HammerPressCustomAttribute, [{
+    key: 'attached',
+    value: function attached() {
+      this.hammer.on('press', this.handleSwipe.bind(this));
+    }
+  }, {
+    key: 'detached',
+    value: function detached() {
+      this.hammer.off('press', this.handleSwipe.bind(this));
+    }
+  }, {
+    key: 'valueChanged',
+    value: function valueChanged(newValue) {
+      this.callback = newValue;
+    }
+  }, {
+    key: 'handleSwipe',
+    value: function handleSwipe(event) {
+      if (this.callback) {
+        this.callback.call(null, { hammerEvent: event });
+      }
+    }
+  }]);
+
+  var _HammerPressCustomAttribute = HammerPressCustomAttribute;
+  HammerPressCustomAttribute = (0, _aureliaFramework.inject)(Element)(HammerPressCustomAttribute) || HammerPressCustomAttribute;
+  HammerPressCustomAttribute = (0, _aureliaFramework.customAttribute)('hammer-press')(HammerPressCustomAttribute) || HammerPressCustomAttribute;
+  return HammerPressCustomAttribute;
+})();
+
+exports.HammerPressCustomAttribute = HammerPressCustomAttribute;

--- a/dist/commonjs/hammer-press.js
+++ b/dist/commonjs/hammer-press.js
@@ -1,0 +1,59 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+
+var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
+
+var _aureliaFramework = require('aurelia-framework');
+
+var _hammerjs = require('hammerjs');
+
+var _hammerjs2 = _interopRequireDefault(_hammerjs);
+
+var HammerPressCustomAttribute = (function () {
+  function HammerPressCustomAttribute(element) {
+    _classCallCheck(this, _HammerPressCustomAttribute);
+
+    this.hammer = new _hammerjs2['default'].Manager(element, {
+      recognizers: [[_hammerjs2['default'].Press]]
+    });
+    this.element = element;
+  }
+
+  _createClass(HammerPressCustomAttribute, [{
+    key: 'attached',
+    value: function attached() {
+      this.hammer.on('press', this.handleSwipe.bind(this));
+    }
+  }, {
+    key: 'detached',
+    value: function detached() {
+      this.hammer.off('press', this.handleSwipe.bind(this));
+    }
+  }, {
+    key: 'valueChanged',
+    value: function valueChanged(newValue) {
+      this.callback = newValue;
+    }
+  }, {
+    key: 'handleSwipe',
+    value: function handleSwipe(event) {
+      if (this.callback) {
+        this.callback.call(null, { hammerEvent: event });
+      }
+    }
+  }]);
+
+  var _HammerPressCustomAttribute = HammerPressCustomAttribute;
+  HammerPressCustomAttribute = (0, _aureliaFramework.inject)(Element)(HammerPressCustomAttribute) || HammerPressCustomAttribute;
+  HammerPressCustomAttribute = (0, _aureliaFramework.customAttribute)('hammer-press')(HammerPressCustomAttribute) || HammerPressCustomAttribute;
+  return HammerPressCustomAttribute;
+})();
+
+exports.HammerPressCustomAttribute = HammerPressCustomAttribute;

--- a/dist/commonjs/hammer-tap.js
+++ b/dist/commonjs/hammer-tap.js
@@ -1,0 +1,59 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+
+var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
+
+var _aureliaFramework = require('aurelia-framework');
+
+var _hammerjs = require('hammerjs');
+
+var _hammerjs2 = _interopRequireDefault(_hammerjs);
+
+var HammerTapCustomAttribute = (function () {
+  function HammerTapCustomAttribute(element) {
+    _classCallCheck(this, _HammerTapCustomAttribute);
+
+    this.hammer = new _hammerjs2['default'].Manager(element, {
+      recognizers: [[_hammerjs2['default'].Tap]]
+    });
+    this.element = element;
+  }
+
+  _createClass(HammerTapCustomAttribute, [{
+    key: 'attached',
+    value: function attached() {
+      this.hammer.on('press', this.handleTap.bind(this));
+    }
+  }, {
+    key: 'detached',
+    value: function detached() {
+      this.hammer.off('press', this.handleTap.bind(this));
+    }
+  }, {
+    key: 'valueChanged',
+    value: function valueChanged(newValue) {
+      this.callback = newValue;
+    }
+  }, {
+    key: 'handleSwipe',
+    value: function handleSwipe(event) {
+      if (this.callback) {
+        this.callback.call(null, { hammerEvent: event });
+      }
+    }
+  }]);
+
+  var _HammerTapCustomAttribute = HammerTapCustomAttribute;
+  HammerTapCustomAttribute = (0, _aureliaFramework.inject)(Element)(HammerTapCustomAttribute) || HammerTapCustomAttribute;
+  HammerTapCustomAttribute = (0, _aureliaFramework.customAttribute)('hammer-tap')(HammerTapCustomAttribute) || HammerTapCustomAttribute;
+  return HammerTapCustomAttribute;
+})();
+
+exports.HammerTapCustomAttribute = HammerTapCustomAttribute;

--- a/dist/commonjs/hammer-tap.js
+++ b/dist/commonjs/hammer-tap.js
@@ -29,12 +29,12 @@ var HammerTapCustomAttribute = (function () {
   _createClass(HammerTapCustomAttribute, [{
     key: 'attached',
     value: function attached() {
-      this.hammer.on('press', this.handleTap.bind(this));
+      this.hammer.on('tap', this.handleTap.bind(this));
     }
   }, {
     key: 'detached',
     value: function detached() {
-      this.hammer.off('press', this.handleTap.bind(this));
+      this.hammer.off('tap', this.handleTap.bind(this));
     }
   }, {
     key: 'valueChanged',
@@ -42,8 +42,8 @@ var HammerTapCustomAttribute = (function () {
       this.callback = newValue;
     }
   }, {
-    key: 'handleSwipe',
-    value: function handleSwipe(event) {
+    key: 'handleTap',
+    value: function handleTap(event) {
       if (this.callback) {
         this.callback.call(null, { hammerEvent: event });
       }

--- a/dist/commonjs/index.js
+++ b/dist/commonjs/index.js
@@ -7,4 +7,6 @@ exports.configure = configure;
 
 function configure(frameworkConfig) {
   frameworkConfig.globalResources('./hammer-swipe');
+  frameworkConfig.globalResources('./hammer-press');
+  frameworkConfig.globalResources('./hammer-hold');
 }

--- a/dist/commonjs/index.js
+++ b/dist/commonjs/index.js
@@ -7,6 +7,7 @@ exports.configure = configure;
 
 function configure(frameworkConfig) {
   frameworkConfig.globalResources('./hammer-swipe');
+  frameworkConfig.globalResources('./hammer-tap');
   frameworkConfig.globalResources('./hammer-press');
   frameworkConfig.globalResources('./hammer-hold');
 }

--- a/dist/es6/hammer-hold.js
+++ b/dist/es6/hammer-hold.js
@@ -1,0 +1,34 @@
+import {inject, customAttribute} from 'aurelia-framework';
+import Hammer from 'hammerjs';
+
+@customAttribute('hammer-press')
+@inject(Element)
+export class HammerPressCustomAttribute {
+
+  constructor(element) {
+    this.hammer = new Hammer.Manager(element, {
+      recognizers: [
+        [Hammer.Press, { time: 1000 }]
+      ]
+    });
+    this.element = element;
+  }
+
+  attached() {
+    this.hammer.on('press', this.handleSwipe.bind(this));
+  }
+
+  detached() {
+    this.hammer.off('press', this.handleSwipe.bind(this));
+  }
+
+  valueChanged(newValue) {
+    this.callback = newValue;
+  }
+
+  handleSwipe(event) {
+    if (this.callback) {
+      this.callback.call(null, { hammerEvent: event });
+    }
+  }
+}

--- a/dist/es6/hammer-hold.js
+++ b/dist/es6/hammer-hold.js
@@ -1,7 +1,7 @@
 import {inject, customAttribute} from 'aurelia-framework';
 import Hammer from 'hammerjs';
 
-@customAttribute('hammer-press')
+@customAttribute('hammer-hold')
 @inject(Element)
 export class HammerPressCustomAttribute {
 

--- a/dist/es6/hammer-press.js
+++ b/dist/es6/hammer-press.js
@@ -1,0 +1,34 @@
+import {inject, customAttribute} from 'aurelia-framework';
+import Hammer from 'hammerjs';
+
+@customAttribute('hammer-press')
+@inject(Element)
+export class HammerPressCustomAttribute {
+
+  constructor(element) {
+    this.hammer = new Hammer.Manager(element, {
+      recognizers: [
+        [Hammer.Press]
+      ]
+    });
+    this.element = element;
+  }
+
+  attached() {
+    this.hammer.on('press', this.handleSwipe.bind(this));
+  }
+
+  detached() {
+    this.hammer.off('press', this.handleSwipe.bind(this));
+  }
+
+  valueChanged(newValue) {
+    this.callback = newValue;
+  }
+
+  handleSwipe(event) {
+    if (this.callback) {
+      this.callback.call(null, { hammerEvent: event });
+    }
+  }
+}

--- a/dist/es6/hammer-tap.js
+++ b/dist/es6/hammer-tap.js
@@ -15,18 +15,18 @@ export class HammerTapCustomAttribute {
   }
 
   attached() {
-    this.hammer.on('press', this.handleTap.bind(this));
+    this.hammer.on('tap', this.handleTap.bind(this));
   }
 
   detached() {
-    this.hammer.off('press', this.handleTap.bind(this));
+    this.hammer.off('tap', this.handleTap.bind(this));
   }
 
   valueChanged(newValue) {
     this.callback = newValue;
   }
 
-  handleSwipe(event) {
+  handleTap(event) {
     if (this.callback) {
       this.callback.call(null, { hammerEvent: event });
     }

--- a/dist/es6/hammer-tap.js
+++ b/dist/es6/hammer-tap.js
@@ -1,0 +1,34 @@
+import {inject, customAttribute} from 'aurelia-framework';
+import Hammer from 'hammerjs';
+
+@customAttribute('hammer-tap')
+@inject(Element)
+export class HammerTapCustomAttribute {
+
+  constructor(element) {
+    this.hammer = new Hammer.Manager(element, {
+      recognizers: [
+        [Hammer.Tap]
+      ]
+    });
+    this.element = element;
+  }
+
+  attached() {
+    this.hammer.on('press', this.handleTap.bind(this));
+  }
+
+  detached() {
+    this.hammer.off('press', this.handleTap.bind(this));
+  }
+
+  valueChanged(newValue) {
+    this.callback = newValue;
+  }
+
+  handleSwipe(event) {
+    if (this.callback) {
+      this.callback.call(null, { hammerEvent: event });
+    }
+  }
+}

--- a/dist/es6/index.js
+++ b/dist/es6/index.js
@@ -1,3 +1,5 @@
 export function configure(frameworkConfig) {
   frameworkConfig.globalResources('./hammer-swipe');
+  frameworkConfig.globalResources('./hammer-press');
+  frameworkConfig.globalResources('./hammer-hold');
 }

--- a/dist/es6/index.js
+++ b/dist/es6/index.js
@@ -1,5 +1,6 @@
 export function configure(frameworkConfig) {
   frameworkConfig.globalResources('./hammer-swipe');
+  frameworkConfig.globalResources('./hammer-tap');
   frameworkConfig.globalResources('./hammer-press');
   frameworkConfig.globalResources('./hammer-hold');
 }

--- a/dist/system/hammer-hold.js
+++ b/dist/system/hammer-hold.js
@@ -51,7 +51,7 @@ System.register(['aurelia-framework', 'hammerjs'], function (_export) {
 
         var _HammerPressCustomAttribute = HammerPressCustomAttribute;
         HammerPressCustomAttribute = inject(Element)(HammerPressCustomAttribute) || HammerPressCustomAttribute;
-        HammerPressCustomAttribute = customAttribute('hammer-press')(HammerPressCustomAttribute) || HammerPressCustomAttribute;
+        HammerPressCustomAttribute = customAttribute('hammer-hold')(HammerPressCustomAttribute) || HammerPressCustomAttribute;
         return HammerPressCustomAttribute;
       })();
 

--- a/dist/system/hammer-hold.js
+++ b/dist/system/hammer-hold.js
@@ -1,0 +1,61 @@
+System.register(['aurelia-framework', 'hammerjs'], function (_export) {
+  'use strict';
+
+  var inject, customAttribute, Hammer, HammerPressCustomAttribute;
+
+  var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+  function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
+
+  return {
+    setters: [function (_aureliaFramework) {
+      inject = _aureliaFramework.inject;
+      customAttribute = _aureliaFramework.customAttribute;
+    }, function (_hammerjs) {
+      Hammer = _hammerjs['default'];
+    }],
+    execute: function () {
+      HammerPressCustomAttribute = (function () {
+        function HammerPressCustomAttribute(element) {
+          _classCallCheck(this, _HammerPressCustomAttribute);
+
+          this.hammer = new Hammer.Manager(element, {
+            recognizers: [[Hammer.Press, { time: 1000 }]]
+          });
+          this.element = element;
+        }
+
+        _createClass(HammerPressCustomAttribute, [{
+          key: 'attached',
+          value: function attached() {
+            this.hammer.on('press', this.handleSwipe.bind(this));
+          }
+        }, {
+          key: 'detached',
+          value: function detached() {
+            this.hammer.off('press', this.handleSwipe.bind(this));
+          }
+        }, {
+          key: 'valueChanged',
+          value: function valueChanged(newValue) {
+            this.callback = newValue;
+          }
+        }, {
+          key: 'handleSwipe',
+          value: function handleSwipe(event) {
+            if (this.callback) {
+              this.callback.call(null, { hammerEvent: event });
+            }
+          }
+        }]);
+
+        var _HammerPressCustomAttribute = HammerPressCustomAttribute;
+        HammerPressCustomAttribute = inject(Element)(HammerPressCustomAttribute) || HammerPressCustomAttribute;
+        HammerPressCustomAttribute = customAttribute('hammer-press')(HammerPressCustomAttribute) || HammerPressCustomAttribute;
+        return HammerPressCustomAttribute;
+      })();
+
+      _export('HammerPressCustomAttribute', HammerPressCustomAttribute);
+    }
+  };
+});

--- a/dist/system/hammer-press.js
+++ b/dist/system/hammer-press.js
@@ -1,0 +1,61 @@
+System.register(['aurelia-framework', 'hammerjs'], function (_export) {
+  'use strict';
+
+  var inject, customAttribute, Hammer, HammerPressCustomAttribute;
+
+  var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+  function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
+
+  return {
+    setters: [function (_aureliaFramework) {
+      inject = _aureliaFramework.inject;
+      customAttribute = _aureliaFramework.customAttribute;
+    }, function (_hammerjs) {
+      Hammer = _hammerjs['default'];
+    }],
+    execute: function () {
+      HammerPressCustomAttribute = (function () {
+        function HammerPressCustomAttribute(element) {
+          _classCallCheck(this, _HammerPressCustomAttribute);
+
+          this.hammer = new Hammer.Manager(element, {
+            recognizers: [[Hammer.Press]]
+          });
+          this.element = element;
+        }
+
+        _createClass(HammerPressCustomAttribute, [{
+          key: 'attached',
+          value: function attached() {
+            this.hammer.on('press', this.handleSwipe.bind(this));
+          }
+        }, {
+          key: 'detached',
+          value: function detached() {
+            this.hammer.off('press', this.handleSwipe.bind(this));
+          }
+        }, {
+          key: 'valueChanged',
+          value: function valueChanged(newValue) {
+            this.callback = newValue;
+          }
+        }, {
+          key: 'handleSwipe',
+          value: function handleSwipe(event) {
+            if (this.callback) {
+              this.callback.call(null, { hammerEvent: event });
+            }
+          }
+        }]);
+
+        var _HammerPressCustomAttribute = HammerPressCustomAttribute;
+        HammerPressCustomAttribute = inject(Element)(HammerPressCustomAttribute) || HammerPressCustomAttribute;
+        HammerPressCustomAttribute = customAttribute('hammer-press')(HammerPressCustomAttribute) || HammerPressCustomAttribute;
+        return HammerPressCustomAttribute;
+      })();
+
+      _export('HammerPressCustomAttribute', HammerPressCustomAttribute);
+    }
+  };
+});

--- a/dist/system/hammer-tap.js
+++ b/dist/system/hammer-tap.js
@@ -1,0 +1,61 @@
+System.register(['aurelia-framework', 'hammerjs'], function (_export) {
+  'use strict';
+
+  var inject, customAttribute, Hammer, HammerTapCustomAttribute;
+
+  var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+  function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
+
+  return {
+    setters: [function (_aureliaFramework) {
+      inject = _aureliaFramework.inject;
+      customAttribute = _aureliaFramework.customAttribute;
+    }, function (_hammerjs) {
+      Hammer = _hammerjs['default'];
+    }],
+    execute: function () {
+      HammerTapCustomAttribute = (function () {
+        function HammerTapCustomAttribute(element) {
+          _classCallCheck(this, _HammerTapCustomAttribute);
+
+          this.hammer = new Hammer.Manager(element, {
+            recognizers: [[Hammer.Tap]]
+          });
+          this.element = element;
+        }
+
+        _createClass(HammerTapCustomAttribute, [{
+          key: 'attached',
+          value: function attached() {
+            this.hammer.on('press', this.handleTap.bind(this));
+          }
+        }, {
+          key: 'detached',
+          value: function detached() {
+            this.hammer.off('press', this.handleTap.bind(this));
+          }
+        }, {
+          key: 'valueChanged',
+          value: function valueChanged(newValue) {
+            this.callback = newValue;
+          }
+        }, {
+          key: 'handleSwipe',
+          value: function handleSwipe(event) {
+            if (this.callback) {
+              this.callback.call(null, { hammerEvent: event });
+            }
+          }
+        }]);
+
+        var _HammerTapCustomAttribute = HammerTapCustomAttribute;
+        HammerTapCustomAttribute = inject(Element)(HammerTapCustomAttribute) || HammerTapCustomAttribute;
+        HammerTapCustomAttribute = customAttribute('hammer-tap')(HammerTapCustomAttribute) || HammerTapCustomAttribute;
+        return HammerTapCustomAttribute;
+      })();
+
+      _export('HammerTapCustomAttribute', HammerTapCustomAttribute);
+    }
+  };
+});

--- a/dist/system/hammer-tap.js
+++ b/dist/system/hammer-tap.js
@@ -28,12 +28,12 @@ System.register(['aurelia-framework', 'hammerjs'], function (_export) {
         _createClass(HammerTapCustomAttribute, [{
           key: 'attached',
           value: function attached() {
-            this.hammer.on('press', this.handleTap.bind(this));
+            this.hammer.on('tap', this.handleTap.bind(this));
           }
         }, {
           key: 'detached',
           value: function detached() {
-            this.hammer.off('press', this.handleTap.bind(this));
+            this.hammer.off('tap', this.handleTap.bind(this));
           }
         }, {
           key: 'valueChanged',
@@ -41,8 +41,8 @@ System.register(['aurelia-framework', 'hammerjs'], function (_export) {
             this.callback = newValue;
           }
         }, {
-          key: 'handleSwipe',
-          value: function handleSwipe(event) {
+          key: 'handleTap',
+          value: function handleTap(event) {
             if (this.callback) {
               this.callback.call(null, { hammerEvent: event });
             }

--- a/dist/system/index.js
+++ b/dist/system/index.js
@@ -5,6 +5,7 @@ System.register([], function (_export) {
 
   function configure(frameworkConfig) {
     frameworkConfig.globalResources('./hammer-swipe');
+    frameworkConfig.globalResources('./hammer-tap');
     frameworkConfig.globalResources('./hammer-press');
     frameworkConfig.globalResources('./hammer-hold');
   }

--- a/dist/system/index.js
+++ b/dist/system/index.js
@@ -5,6 +5,8 @@ System.register([], function (_export) {
 
   function configure(frameworkConfig) {
     frameworkConfig.globalResources('./hammer-swipe');
+    frameworkConfig.globalResources('./hammer-press');
+    frameworkConfig.globalResources('./hammer-hold');
   }
 
   return {

--- a/src/hammer-hold.js
+++ b/src/hammer-hold.js
@@ -1,0 +1,34 @@
+import {inject, customAttribute} from 'aurelia-framework';
+import Hammer from 'hammerjs';
+
+@customAttribute('hammer-press')
+@inject(Element)
+export class HammerPressCustomAttribute {
+
+  constructor(element) {
+    this.hammer = new Hammer.Manager(element, {
+      recognizers: [
+        [Hammer.Press, { time: 1000 }]
+      ]
+    });
+    this.element = element;
+  }
+
+  attached() {
+    this.hammer.on('press', this.handleSwipe.bind(this));
+  }
+
+  detached() {
+    this.hammer.off('press', this.handleSwipe.bind(this));
+  }
+
+  valueChanged(newValue) {
+    this.callback = newValue;
+  }
+
+  handleSwipe(event) {
+    if (this.callback) {
+      this.callback.call(null, { hammerEvent: event });
+    }
+  }
+}

--- a/src/hammer-hold.js
+++ b/src/hammer-hold.js
@@ -1,7 +1,7 @@
 import {inject, customAttribute} from 'aurelia-framework';
 import Hammer from 'hammerjs';
 
-@customAttribute('hammer-press')
+@customAttribute('hammer-hold')
 @inject(Element)
 export class HammerPressCustomAttribute {
 

--- a/src/hammer-press.js
+++ b/src/hammer-press.js
@@ -1,0 +1,34 @@
+import {inject, customAttribute} from 'aurelia-framework';
+import Hammer from 'hammerjs';
+
+@customAttribute('hammer-press')
+@inject(Element)
+export class HammerPressCustomAttribute {
+
+  constructor(element) {
+    this.hammer = new Hammer.Manager(element, {
+      recognizers: [
+        [Hammer.Press]
+      ]
+    });
+    this.element = element;
+  }
+
+  attached() {
+    this.hammer.on('press', this.handleSwipe.bind(this));
+  }
+
+  detached() {
+    this.hammer.off('press', this.handleSwipe.bind(this));
+  }
+
+  valueChanged(newValue) {
+    this.callback = newValue;
+  }
+
+  handleSwipe(event) {
+    if (this.callback) {
+      this.callback.call(null, { hammerEvent: event });
+    }
+  }
+}

--- a/src/hammer-tap.js
+++ b/src/hammer-tap.js
@@ -26,7 +26,7 @@ export class HammerTapCustomAttribute {
     this.callback = newValue;
   }
 
-  handleSwipe(event) {
+  handleTap(event) {
     if (this.callback) {
       this.callback.call(null, { hammerEvent: event });
     }

--- a/src/hammer-tap.js
+++ b/src/hammer-tap.js
@@ -1,0 +1,34 @@
+import {inject, customAttribute} from 'aurelia-framework';
+import Hammer from 'hammerjs';
+
+@customAttribute('hammer-tap')
+@inject(Element)
+export class HammerTapCustomAttribute {
+
+  constructor(element) {
+    this.hammer = new Hammer.Manager(element, {
+      recognizers: [
+        [Hammer.Tap]
+      ]
+    });
+    this.element = element;
+  }
+
+  attached() {
+    this.hammer.on('press', this.handleTap.bind(this));
+  }
+
+  detached() {
+    this.hammer.off('press', this.handleTap.bind(this));
+  }
+
+  valueChanged(newValue) {
+    this.callback = newValue;
+  }
+
+  handleSwipe(event) {
+    if (this.callback) {
+      this.callback.call(null, { hammerEvent: event });
+    }
+  }
+}

--- a/src/hammer-tap.js
+++ b/src/hammer-tap.js
@@ -15,11 +15,11 @@ export class HammerTapCustomAttribute {
   }
 
   attached() {
-    this.hammer.on('press', this.handleTap.bind(this));
+    this.hammer.on('tap', this.handleTap.bind(this));
   }
 
   detached() {
-    this.hammer.off('press', this.handleTap.bind(this));
+    this.hammer.off('tap', this.handleTap.bind(this));
   }
 
   valueChanged(newValue) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
 export function configure(frameworkConfig) {
   frameworkConfig.globalResources('./hammer-swipe');
+  frameworkConfig.globalResources('./hammer-press');
+  frameworkConfig.globalResources('./hammer-hold');
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 export function configure(frameworkConfig) {
   frameworkConfig.globalResources('./hammer-swipe');
+  frameworkConfig.globalResources('./hammer-tap');
   frameworkConfig.globalResources('./hammer-press');
   frameworkConfig.globalResources('./hammer-hold');
 }


### PR DESCRIPTION
self-explanatory. Check [README.md](https://github.com/nderscore/aurelia-hammer/blob/85a49e5b65ad5d01bfa6798c378f31b6722cce33/README.md) for details on `press` vs `hold`.
